### PR TITLE
[codex] Add Go plugin template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Local isolated worktrees
+.worktrees/

--- a/docs/superpowers/plans/2026-06-29-go-plugin-template.md
+++ b/docs/superpowers/plans/2026-06-29-go-plugin-template.md
@@ -1,0 +1,904 @@
+# Go Plugin Template Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Python-aligned Go plugin cookiecutter template and expose `MustInstallV2` form metadata through the Go detail protocol.
+
+**Architecture:** Keep `bk-plugin-framework-go` as the SDK/protocol owner and make a narrow protocol change there. Add a minimal generated plugin project under `template/` that uses `bk-plugin-runtime-go` for server, worker, APIGW sync, and public-key fetch. The template defaults to framework `v1.0.4` as the first tag expected to contain the protocol fix, and runtime `v0.2.5`.
+
+**Tech Stack:** Go 1.23 templates, `bk-plugin-framework-go`, `bk-plugin-runtime-go`, cookiecutter, PaaS v3 `app_desc.yml`, shell pre-release hook.
+
+---
+
+## File Map
+
+- Modify `hub/registry.go`: track whether a plugin version has explicit renderform metadata.
+- Modify `hub/registry_test.go`: lock legacy and `MustInstallV2` renderform flags.
+- Modify `protocol/detail.go`: default detail `forms.renderform` from explicit `MustInstallV2` form metadata.
+- Modify `protocol/protocol_test.go`: expect `MustInstallV2` renderform in detail and keep legacy renderform nil.
+- Modify `info/version.go`: prepare framework version string `v1.0.4`.
+- Create `template/cookiecutter.json`: user-facing template variables.
+- Create `template/{{cookiecutter.project_name}}/.gitignore`: generated project ignores.
+- Create `template/{{cookiecutter.project_name}}/README.md`: generated project usage and v2 deployment adaptation.
+- Create `template/{{cookiecutter.project_name}}/app_desc.yml`: PaaS v3 deployment.
+- Create `template/{{cookiecutter.project_name}}/go.mod`: generated module dependencies.
+- Create `template/{{cookiecutter.project_name}}/main.go`: plugin registration and runtime entry.
+- Create `template/{{cookiecutter.project_name}}/bin/sync_apigateway.sh`: pre-release APIGW sync.
+- Create `template/{{cookiecutter.project_name}}/versions/v100/form.json`: default input form.
+- Create `template/{{cookiecutter.project_name}}/versions/v100/plugin.go`: default hello/world plugin.
+- Create `template/{{cookiecutter.project_name}}/versions/v100/plugin_test.go`: default plugin unit tests.
+
+## Task 1: Align Detail Renderform Protocol
+
+**Files:**
+- Modify: `hub/registry.go`
+- Modify: `hub/registry_test.go`
+- Modify: `protocol/detail.go`
+- Modify: `protocol/protocol_test.go`
+
+- [ ] **Step 1: Write failing hub tests for explicit renderform tracking**
+
+Update `TestPluginDetailPlugin`, `TestMustInstallLegacyKeepsInputsFormAsInputsSchema`, and `TestMustInstallV2StoresExplicitSchemasAndForm` in `hub/registry_test.go` with these assertions:
+
+```go
+func TestPluginDetailPlugin(t *testing.T) {
+	plugin := MetaTestPlugin{}
+	inputsSchema := []byte("{\"inputsSchema\": 1}")
+	contextInputsSchema := []byte("{\"contextInputsSchema\": 2}")
+	outputsSchema := []byte("{\"outputsSchema\": 3}")
+	inputsSchemaJSON := map[string]interface{}{"inputsSchema": 1}
+	contextInputsSchemaJSON := map[string]interface{}{"contextInputsSchema": 2}
+	outputsSchemaJSON := map[string]interface{}{"outputsSchema": 3}
+	formsRenderFormJSON := map[string]interface{}{"template_id": "render"}
+
+	detail := PluginDetail{
+		plugin:                  &plugin,
+		inputsSchema:            inputsSchema,
+		contextInputsSchema:     contextInputsSchema,
+		outputsSchema:           outputsSchema,
+		inputsSchemaJSON:        inputsSchemaJSON,
+		contextInputsSchemaJSON: contextInputsSchemaJSON,
+		outputsSchemaJSON:       outputsSchemaJSON,
+		formsRenderFormJSON:     formsRenderFormJSON,
+		formsRenderFormEnabled:  true,
+	}
+
+	assert.Equal(t, detail.Plugin(), &plugin)
+	assert.Equal(t, detail.InputsSchema(), inputsSchema)
+	assert.Equal(t, detail.ContextInputsSchema(), contextInputsSchema)
+	assert.Equal(t, detail.OutputsSchema(), outputsSchema)
+	assert.Equal(t, detail.InputsSchemaJSON(), inputsSchemaJSON)
+	assert.Equal(t, detail.ContextInputsSchemaJSON(), contextInputsSchemaJSON)
+	assert.Equal(t, detail.OutputsSchemaJSON(), outputsSchemaJSON)
+	assert.Equal(t, detail.FormsRenderFormJSON(), formsRenderFormJSON)
+	assert.True(t, detail.FormsRenderFormEnabled())
+}
+```
+
+In `TestMustInstallLegacyKeepsInputsFormAsInputsSchema`, add:
+
+```go
+assert.False(t, detail.FormsRenderFormEnabled())
+```
+
+In `TestMustInstallV2StoresExplicitSchemasAndForm`, add:
+
+```go
+assert.True(t, detail.FormsRenderFormEnabled())
+```
+
+- [ ] **Step 2: Write failing protocol test for `MustInstallV2` renderform**
+
+Replace `TestBuildDetailKeepsGoJSONSchemaOutOfRenderForm` in `protocol/protocol_test.go` with:
+
+```go
+func TestBuildDetailIncludesExplicitRenderForm(t *testing.T) {
+	version := nextProtocolTestVersion()
+	hub.MustInstallV2(protocolTestPlugin{version: version, desc: "detail plugin"}, hub.PluginSpec{
+		Inputs: struct {
+			Mode string `json:"mode"`
+		}{},
+		Outputs: struct {
+			OK bool `json:"ok"`
+		}{},
+		Form: []byte(`{"mode":{"component":"input"}}`),
+	})
+
+	data, err := BuildDetail(version, DetailOptions{EnablePluginCallback: true})
+	require.NoError(t, err)
+	require.Equal(t, version, data.Version)
+	require.Equal(t, "detail plugin", data.Desc)
+	require.True(t, data.EnablePluginCallback)
+	require.Contains(t, data.Inputs["properties"], "mode")
+	require.Contains(t, data.Outputs["properties"], "ok")
+	require.Equal(t, map[string]interface{}{
+		"mode": map[string]interface{}{"component": "input"},
+	}, data.Forms.RenderForm)
+
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), `"renderform":{"mode":{"component":"input"}}`)
+}
+```
+
+Keep `TestBuildDetailKeepsLegacyInputsFormAsInputs` unchanged so it still requires legacy renderform to be nil.
+
+- [ ] **Step 3: Run tests and confirm they fail for the intended reason**
+
+Run:
+
+```bash
+go test ./hub ./protocol -count=1
+```
+
+Expected: FAIL because `FormsRenderFormEnabled` and `formsRenderFormEnabled` do not exist, and/or protocol detail still returns nil renderform.
+
+- [ ] **Step 4: Implement explicit renderform tracking in `hub/registry.go`**
+
+Add a field and accessor to `PluginDetail`:
+
+```go
+type PluginDetail struct {
+	plugin                  kit.Plugin
+	inputsSchema            []byte
+	contextInputsSchema     []byte
+	outputsSchema           []byte
+	inputsSchemaJSON        map[string]interface{}
+	contextInputsSchemaJSON map[string]interface{}
+	outputsSchemaJSON       map[string]interface{}
+	formsRenderFormJSON     map[string]interface{}
+	formsRenderFormEnabled  bool
+}
+```
+
+Add this method after `FormsRenderFormJSON()`:
+
+```go
+// FormsRenderFormEnabled returns whether the render form metadata should be
+// exposed as forms.renderform in the plugin detail protocol.
+func (p *PluginDetail) FormsRenderFormEnabled() bool {
+	return p.formsRenderFormEnabled
+}
+```
+
+In `mustInstallDetail`, compute the flag after form parsing:
+
+```go
+formsRenderFormEnabled := !legacyInputsFormAsSchema && len(spec.Form) > 0
+if legacyInputsFormAsSchema {
+	inputsSchema = spec.Form
+	inputsSchemaJSON = formsRenderFormJSON
+}
+```
+
+Store the flag in the hub entry:
+
+```go
+hub[v] = &PluginDetail{
+	plugin:                  p,
+	inputsSchema:            inputsSchema,
+	contextInputsSchema:     contextInputsSchema,
+	outputsSchema:           outputsSchema,
+	inputsSchemaJSON:        inputsSchemaJSON,
+	contextInputsSchemaJSON: contextInputsSchemaJSON,
+	outputsSchemaJSON:       outputsSchemaJSON,
+	formsRenderFormJSON:     formsRenderFormJSON,
+	formsRenderFormEnabled:  formsRenderFormEnabled,
+}
+```
+
+- [ ] **Step 5: Implement renderform defaulting in `protocol/detail.go`**
+
+Replace `BuildDetail` with:
+
+```go
+// BuildDetail builds the standard plugin service detail payload.
+func BuildDetail(version string, opts DetailOptions) (DetailData, error) {
+	detail, err := hub.GetPluginDetail(version)
+	if err != nil {
+		return DetailData{}, err
+	}
+
+	renderForm := opts.RenderForm
+	if renderForm == nil && detail.FormsRenderFormEnabled() {
+		renderForm = detail.FormsRenderFormJSON()
+	}
+
+	return DetailData{
+		Version:              detail.Plugin().Version(),
+		Desc:                 detail.Plugin().Desc(),
+		EnablePluginCallback: opts.EnablePluginCallback,
+		Inputs:               detail.InputsSchemaJSON(),
+		ContextInputs:        detail.ContextInputsSchemaJSON(),
+		Outputs:              detail.OutputsSchemaJSON(),
+		Forms: DetailForms{
+			RenderForm: renderForm,
+		},
+	}, nil
+}
+```
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+go test ./hub ./protocol -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run full framework tests**
+
+Run:
+
+```bash
+go test ./... -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit protocol alignment**
+
+Run:
+
+```bash
+git add hub/registry.go hub/registry_test.go protocol/detail.go protocol/protocol_test.go
+git commit -m "feat: expose explicit plugin render form"
+```
+
+## Task 2: Prepare Framework Version for Template Pin
+
+**Files:**
+- Modify: `info/version.go`
+- Test: `info/version_test.go`
+
+- [ ] **Step 1: Update framework version string**
+
+Change `info/version.go` to:
+
+```go
+// TencentBlueKing is pleased to support the open source community by making
+// 蓝鲸智云-gopkg available.
+// Copyright (C) 2017-2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Package info store basic information of bk-plugin-framework-go.
+package info
+
+const (
+	version = "v1.0.4"
+)
+
+// Version returns the current version number of bk-plugin-framework-go.
+func Version() string {
+	return version
+}
+```
+
+- [ ] **Step 2: Run version tests**
+
+Run:
+
+```bash
+go test ./info -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit version prep**
+
+Run:
+
+```bash
+git add info/version.go
+git commit -m "chore: bump framework version to v1.0.4"
+```
+
+## Task 3: Add Template Project Skeleton
+
+**Files:**
+- Create: `template/cookiecutter.json`
+- Create: `template/{{cookiecutter.project_name}}/.gitignore`
+- Create: `template/{{cookiecutter.project_name}}/README.md`
+- Create: `template/{{cookiecutter.project_name}}/app_desc.yml`
+- Create: `template/{{cookiecutter.project_name}}/go.mod`
+- Create: `template/{{cookiecutter.project_name}}/bin/sync_apigateway.sh`
+
+- [ ] **Step 1: Create `template/cookiecutter.json`**
+
+Create the file with:
+
+```json
+{
+  "project_name": "my_plugin",
+  "app_code": "the app code of plugin saas",
+  "plugin_desc": "the description of this plugin",
+  "init_apigw_maintainer": "admin",
+  "framework_version": "v1.0.4",
+  "runtime_version": "v0.2.5"
+}
+```
+
+- [ ] **Step 2: Create generated project `.gitignore`**
+
+Create `template/{{cookiecutter.project_name}}/.gitignore` with:
+
+```gitignore
+# Build outputs
+bin/apigw.pub
+dist/
+build/
+*.test
+
+# Go
+vendor/
+coverage.out
+
+# Logs and local env
+v3logs/
+.env
+
+# Editors and OS files
+.idea/
+.vscode/
+.DS_Store
+```
+
+- [ ] **Step 3: Create generated project `README.md`**
+
+Create `template/{{cookiecutter.project_name}}/README.md` with:
+
+```markdown
+# {{cookiecutter.project_name}}
+
+{{cookiecutter.plugin_desc}}
+
+## Structure
+
+```text
+.
+├── app_desc.yml
+├── bin/sync_apigateway.sh
+├── main.go
+└── versions/v100
+    ├── form.json
+    ├── plugin.go
+    └── plugin_test.go
+```
+
+The default version is `1.0.0`. It reads `hello` and writes `world` with the same value.
+
+## Local Checks
+
+```bash
+go test ./... -count=1
+go build ./... 
+```
+
+## Runtime Commands
+
+```bash
+{{cookiecutter.project_name}} server
+{{cookiecutter.project_name}} worker
+{{cookiecutter.project_name}} syncapigw
+{{cookiecutter.project_name}} fetch-apigw-public-key
+```
+
+## PaaS Deployment
+
+`app_desc.yml` uses PaaS v3 by default. The pre-release hook runs:
+
+```bash
+bash bin/sync_apigateway.sh
+```
+
+The script syncs the runtime-owned APIGW resources and fetches the gateway public key into `bin/apigw.pub`.
+
+Important environment variables are injected by PaaS or configured on the app:
+
+- `BKPAAS_APP_ID`
+- `BKPAAS_APP_SECRET`
+- `BKPAAS_DEFAULT_PREALLOCATED_URLS`
+- `BK_APIGW_MANAGER_URL_TMPL`
+- `BK_APIGW_MAINTAINERS`
+
+The default synchronous plugin does not require callback configuration. If you enable callback features later, configure `BK_PLUGIN_CALLBACK_TOKEN_SECRET`.
+
+## Legacy `spec_version: 2` Deployment
+
+If the target environment still uses the older Go app descriptor shape, adapt the process section to:
+
+```yaml
+spec_version: 2
+modules:
+  default:
+    language: go
+    is_default: true
+    processes:
+      web:
+        command: {{cookiecutter.project_name}} server
+      worker:
+        command: {{cookiecutter.project_name}} worker
+    services:
+      - name: mysql
+      - name: redis
+```
+
+Add RabbitMQ only if your platform requires it for this runtime deployment.
+```
+
+- [ ] **Step 4: Create PaaS v3 `app_desc.yml`**
+
+Create `template/{{cookiecutter.project_name}}/app_desc.yml` with:
+
+```yaml
+specVersion: 3
+modules:
+  - name: default
+    isDefault: true
+    language: go
+    spec:
+      hooks:
+        preRelease:
+          procCommand: bash bin/sync_apigateway.sh
+      processes:
+        - name: web
+          procCommand: {{cookiecutter.project_name}} server
+          services:
+            - name: web
+              exposedType:
+                name: bk/http
+              targetPort: 5000
+              port: 80
+        - name: worker
+          procCommand: {{cookiecutter.project_name}} worker
+      services:
+        - name: mysql
+        - name: redis
+      configuration:
+        env:
+          - name: BK_APIGW_MAINTAINERS
+            value: {{cookiecutter.init_apigw_maintainer}}
+            description: plugin apigw maintainers
+```
+
+- [ ] **Step 5: Create generated project `go.mod`**
+
+Create `template/{{cookiecutter.project_name}}/go.mod` with:
+
+```go
+// +heroku install {{cookiecutter.project_name}}
+// +heroku goVersion go1.23
+module {{cookiecutter.project_name}}
+
+go 1.23.0
+
+require (
+	github.com/TencentBlueKing/bk-plugin-framework-go {{cookiecutter.framework_version}}
+	github.com/TencentBlueKing/bk-plugin-runtime-go {{cookiecutter.runtime_version}}
+	github.com/sirupsen/logrus v1.9.2
+)
+```
+
+- [ ] **Step 6: Create APIGW sync script**
+
+Create `template/{{cookiecutter.project_name}}/bin/sync_apigateway.sh` with:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[Sync] BEGIN ====================="
+
+{{cookiecutter.project_name}} syncapigw
+{{cookiecutter.project_name}} fetch-apigw-public-key
+
+echo "[Sync] DONE ====================="
+```
+
+- [ ] **Step 7: Commit template skeleton**
+
+Run:
+
+```bash
+git add template/cookiecutter.json \
+  'template/{{cookiecutter.project_name}}/.gitignore' \
+  'template/{{cookiecutter.project_name}}/README.md' \
+  'template/{{cookiecutter.project_name}}/app_desc.yml' \
+  'template/{{cookiecutter.project_name}}/go.mod' \
+  'template/{{cookiecutter.project_name}}/bin/sync_apigateway.sh'
+git commit -m "feat: add go plugin template skeleton"
+```
+
+## Task 4: Add Default Plugin Version and Tests
+
+**Files:**
+- Create: `template/{{cookiecutter.project_name}}/main.go`
+- Create: `template/{{cookiecutter.project_name}}/versions/v100/form.json`
+- Create: `template/{{cookiecutter.project_name}}/versions/v100/plugin.go`
+- Create: `template/{{cookiecutter.project_name}}/versions/v100/plugin_test.go`
+
+- [ ] **Step 1: Create generated project `main.go`**
+
+Create `template/{{cookiecutter.project_name}}/main.go` with:
+
+```go
+package main
+
+import (
+	"github.com/TencentBlueKing/bk-plugin-framework-go/hub"
+	"github.com/TencentBlueKing/bk-plugin-runtime-go/runner"
+	v100 "{{cookiecutter.project_name}}/versions/v100"
+)
+
+func main() {
+	hub.MustInstallV2(&v100.Plugin{}, hub.PluginSpec{
+		Inputs:        v100.Inputs{},
+		ContextInputs: v100.ContextInputs{},
+		Outputs:       v100.Outputs{},
+		Form:          v100.InputsForm,
+	})
+	runner.Run()
+}
+```
+
+- [ ] **Step 2: Create `form.json`**
+
+Create `template/{{cookiecutter.project_name}}/versions/v100/form.json` with:
+
+```json
+{
+  "hello": {
+    "type": "string",
+    "title": "Hello",
+    "default": "",
+    "ui:component": {
+      "name": "bk-input",
+      "props": {}
+    },
+    "ui:rules": [
+      "required"
+    ]
+  }
+}
+```
+
+- [ ] **Step 3: Create default plugin implementation**
+
+Create `template/{{cookiecutter.project_name}}/versions/v100/plugin.go` with:
+
+```go
+package v100
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/TencentBlueKing/bk-plugin-framework-go/constants"
+	"github.com/TencentBlueKing/bk-plugin-framework-go/kit"
+)
+
+//go:embed form.json
+var InputsForm []byte
+
+// Inputs defines the visible plugin inputs.
+type Inputs struct {
+	Hello string `json:"hello" jsonschema:"title=Hello"`
+}
+
+// ContextInputs defines Standard Ops context inputs used by the plugin.
+type ContextInputs struct {
+	Executor string `json:"executor" jsonschema:"title=Executor"`
+}
+
+// Outputs defines the values returned to the caller.
+type Outputs struct {
+	World string `json:"world" jsonschema:"title=World"`
+}
+
+// Plugin implements version 1.0.0.
+type Plugin struct{}
+
+// Version returns the plugin version.
+func (p *Plugin) Version() string {
+	return "1.0.0"
+}
+
+// Desc returns the plugin description.
+func (p *Plugin) Desc() string {
+	return "{{cookiecutter.plugin_desc}}"
+}
+
+// Execute runs the synchronous hello/world plugin.
+func (p *Plugin) Execute(c *kit.Context) error {
+	if c.State() != constants.StateEmpty {
+		return fmt.Errorf("hello world plugin does not support state %v", c.State())
+	}
+
+	var inputs Inputs
+	if err := c.ReadInputs(&inputs); err != nil {
+		return err
+	}
+
+	var contextInputs ContextInputs
+	if err := c.ReadContextInputs(&contextInputs); err != nil {
+		return err
+	}
+	_ = contextInputs
+
+	return c.WriteOutputs(&Outputs{World: inputs.Hello})
+}
+```
+
+- [ ] **Step 4: Create default plugin tests**
+
+Create `template/{{cookiecutter.project_name}}/versions/v100/plugin_test.go` with:
+
+```go
+package v100
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/TencentBlueKing/bk-plugin-framework-go/constants"
+	"github.com/TencentBlueKing/bk-plugin-framework-go/kit"
+	"github.com/sirupsen/logrus"
+)
+
+type testReader struct {
+	inputs        map[string]interface{}
+	contextInputs map[string]interface{}
+}
+
+func (r testReader) ReadInputs(v interface{}) error {
+	return marshalTo(r.inputs, v)
+}
+
+func (r testReader) ReadContextInputs(v interface{}) error {
+	return marshalTo(r.contextInputs, v)
+}
+
+type testStore struct {
+	data map[string][]byte
+}
+
+func newTestStore() *testStore {
+	return &testStore{data: map[string][]byte{}}
+}
+
+func (s *testStore) Write(traceID string, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	s.data[traceID] = data
+	return nil
+}
+
+func (s *testStore) Read(traceID string, v interface{}) error {
+	return json.Unmarshal(s.data[traceID], v)
+}
+
+func marshalTo(src interface{}, dst interface{}) error {
+	data, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, dst)
+}
+
+func TestHelloWorldPluginWritesOutput(t *testing.T) {
+	contextStore := newTestStore()
+	outputsStore := newTestStore()
+	reader := testReader{
+		inputs: map[string]interface{}{
+			"hello": "world",
+		},
+		contextInputs: map[string]interface{}{
+			"executor": "admin",
+		},
+	}
+
+	plugin := &Plugin{}
+	c := kit.NewContext("trace-hello", constants.StateEmpty, 1, reader, contextStore, outputsStore, logrus.NewEntry(logrus.StandardLogger()))
+	if err := plugin.Execute(c); err != nil {
+		t.Fatalf("execute plugin: %v", err)
+	}
+	if c.WaitingPoll() || c.WaitingCallback() {
+		t.Fatalf("default plugin should finish synchronously")
+	}
+
+	var outputs Outputs
+	if err := outputsStore.Read("trace-hello", &outputs); err != nil {
+		t.Fatalf("read outputs: %v", err)
+	}
+	if outputs.World != "world" {
+		t.Fatalf("World = %q, want %q", outputs.World, "world")
+	}
+}
+
+func TestHelloWorldPluginRejectsUnsupportedState(t *testing.T) {
+	contextStore := newTestStore()
+	outputsStore := newTestStore()
+	reader := testReader{
+		inputs:        map[string]interface{}{"hello": "world"},
+		contextInputs: map[string]interface{}{"executor": "admin"},
+	}
+
+	plugin := &Plugin{}
+	c := kit.NewContext("trace-poll", constants.StatePoll, 2, reader, contextStore, outputsStore, logrus.NewEntry(logrus.StandardLogger()))
+	if err := plugin.Execute(c); err == nil {
+		t.Fatalf("expected unsupported state error")
+	}
+}
+```
+
+- [ ] **Step 5: Commit default plugin**
+
+Run:
+
+```bash
+git add 'template/{{cookiecutter.project_name}}/main.go' \
+  'template/{{cookiecutter.project_name}}/versions/v100/form.json' \
+  'template/{{cookiecutter.project_name}}/versions/v100/plugin.go' \
+  'template/{{cookiecutter.project_name}}/versions/v100/plugin_test.go'
+git commit -m "feat: add default go plugin version"
+```
+
+## Task 5: Render Template and Validate Generated Project
+
+**Files:**
+- Generated temporary files under `/tmp`, not committed.
+- Template `go.sum` handling depends on release availability.
+
+- [ ] **Step 1: Render the template with cookiecutter**
+
+Run:
+
+```bash
+rm -rf /tmp/bk-plugin-template-render
+mkdir -p /tmp/bk-plugin-template-render
+uvx cookiecutter==2.6.0 --no-input template \
+  --output-dir /tmp/bk-plugin-template-render \
+  project_name=rendered_go_plugin \
+  app_code=rendered_go_plugin \
+  plugin_desc="Rendered Go plugin" \
+  init_apigw_maintainer=admin \
+  framework_version=v1.0.4 \
+  runtime_version=v0.2.5
+```
+
+Expected: `/tmp/bk-plugin-template-render/rendered_go_plugin` exists.
+
+- [ ] **Step 2: Add a temporary local replace for pre-release validation**
+
+Until `github.com/TencentBlueKing/bk-plugin-framework-go v1.0.4` is published, run:
+
+```bash
+cd /tmp/bk-plugin-template-render/rendered_go_plugin
+go mod edit -replace github.com/TencentBlueKing/bk-plugin-framework-go=/Users/dengyh/Projects/bk-plugin-framework-go
+```
+
+Expected: `go.mod` contains a local replace. This replace is for validation only and must not be copied back into `template/`.
+
+- [ ] **Step 3: Tidy generated project**
+
+Run:
+
+```bash
+cd /tmp/bk-plugin-template-render/rendered_go_plugin
+go mod tidy
+```
+
+Expected: PASS and a generated `go.sum` appears in the temporary rendered project.
+
+- [ ] **Step 4: Run generated project tests**
+
+Run:
+
+```bash
+cd /tmp/bk-plugin-template-render/rendered_go_plugin
+go test ./... -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Build generated project**
+
+Run:
+
+```bash
+cd /tmp/bk-plugin-template-render/rendered_go_plugin
+go build ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Verify rendered files contain expected runtime wiring**
+
+Run:
+
+```bash
+rg -n "bk-plugin-runtime-go|MustInstallV2|syncapigw|fetch-apigw-public-key|specVersion: 3" /tmp/bk-plugin-template-render/rendered_go_plugin
+```
+
+Expected: output includes `go.mod`, `main.go`, `bin/sync_apigateway.sh`, and `app_desc.yml`.
+
+- [ ] **Step 7: Decide template `go.sum` inclusion**
+
+If `v1.0.4` has been published before implementation reaches this step, remove the temporary replace, run `go mod tidy`, and copy the generated `go.sum` into `template/{{cookiecutter.project_name}}/go.sum`.
+
+If `v1.0.4` has not been published, do not add `template/{{cookiecutter.project_name}}/go.sum`; instead, keep `go.mod` only and document in the final implementation report that official-tag validation is blocked until the `v1.0.4` tag is published. The generated project still validates with the local replace above.
+
+- [ ] **Step 8: Commit template validation adjustments**
+
+If `template/{{cookiecutter.project_name}}/go.sum` was added, run:
+
+```bash
+git add 'template/{{cookiecutter.project_name}}/go.sum'
+git commit -m "chore: add go plugin template sums"
+```
+
+If no `go.sum` was added because `v1.0.4` is unpublished, skip this commit and record the reason in the final implementation report.
+
+## Task 6: Static Checks and Final Documentation Consistency
+
+**Files:**
+- Modify only files that fail the checks from earlier tasks.
+
+- [ ] **Step 1: Check template has no old runtime remnants**
+
+Run:
+
+```bash
+rg -n "beego-runtime|app.json|post-compile|database/migrations" template || true
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Check dependency pins**
+
+Run:
+
+```bash
+rg -n '"framework_version": "v1.0.4"|"runtime_version": "v0.2.5"|github.com/TencentBlueKing/bk-plugin-framework-go {{cookiecutter.framework_version}}|github.com/TencentBlueKing/bk-plugin-runtime-go {{cookiecutter.runtime_version}}' template
+```
+
+Expected: output includes `template/cookiecutter.json` and `template/{{cookiecutter.project_name}}/go.mod`.
+
+- [ ] **Step 3: Run full framework tests again**
+
+Run:
+
+```bash
+go test ./... -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run diff whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Review final status**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate --max-count=8
+```
+
+Expected: branch includes the implementation commits from Tasks 1-4, and only pre-existing unrelated untracked files such as `.serena/` and `docs/session-handoff/` remain untracked.

--- a/docs/superpowers/specs/2026-06-29-go-plugin-template-design.md
+++ b/docs/superpowers/specs/2026-06-29-go-plugin-template-design.md
@@ -1,0 +1,209 @@
+# Go Plugin Template Design
+
+## Context
+
+This work adds a cookiecutter template for new Go BK standard plugins and aligns the Go detail protocol with the Python plugin framework where the template depends on it.
+
+The current `origin/main_with_template` branch is useful as an early Go template reference, but it targets the older `beego-runtime`, uses legacy `hub.MustInstall`, includes a Beego migration stub, and keeps a Heroku-style `app.json`. The new template targets the current split architecture:
+
+- `bk-plugin-framework-go v1.0.3` as the plugin SDK.
+- `bk-plugin-runtime-go v0.2.5` as the HTTP server, worker, APIGW sync, callback, and finish-callback runtime.
+
+Those are the latest observed released tags during design. If the protocol alignment fix below requires a newer framework or runtime release, the template defaults must be updated to the first official tags that contain the fix before claiming that generated projects expose `forms.renderform`.
+
+The Python template is the user-experience reference: after cookiecutter initialization, users should be able to deploy and run a default plugin without editing business code.
+
+## Goals
+
+- Add `template/` for initializing a new Go plugin project.
+- Default to a minimal synchronous `hello -> world` plugin matching the Python template's simplicity.
+- Use official Go module tags, not vendored `third_party` runtime code.
+- Default deployment to PaaS v3 `app_desc.yml`, while documenting how to adapt to legacy `spec_version: 2` deployments.
+- Run APIGW sync and public-key fetch through a pre-release script.
+- Make the detail response expose `forms.renderform` for `hub.MustInstallV2` plugins so the template's form metadata is not silently dropped.
+- Keep legacy `hub.MustInstall` behavior compatible.
+
+## Non-Goals
+
+- Do not vendor `bk-plugin-runtime-go` into generated projects.
+- Do not add poll, callback, or finish-callback examples to the default generated plugin.
+- Do not migrate existing Go plugin projects.
+- Do not replace the runtime's embedded APIGW `definition.yaml` and `resources.yaml` defaults.
+- Do not remove legacy `hub.MustInstall`.
+
+## Recommended Approach
+
+Use a small template plus a small protocol fix.
+
+The template stays clean and deployable. Runtime/framework protocol behavior is corrected only where it affects Python alignment and template correctness: `forms.renderform` should return the form registered through `MustInstallV2`.
+
+## Template Structure
+
+```text
+template/
+  cookiecutter.json
+  {{cookiecutter.project_name}}/
+    .gitignore
+    README.md
+    app_desc.yml
+    go.mod
+    go.sum
+    main.go
+    bin/
+      sync_apigateway.sh
+    versions/
+      v100/
+        form.json
+        plugin.go
+        plugin_test.go
+```
+
+Files deliberately omitted from `main_with_template`:
+
+- `app.json`: Heroku example metadata, not needed for BK PaaS.
+- `bin/pre-compile`: no template-specific compile flags are required.
+- `bin/post-compile`: APIGW sync belongs in the v3 pre-release hook.
+- `database/migrations/...`: the new runtime owns its schedule-store setup; the plugin template should not contain a Beego migration stub.
+
+## Cookiecutter Variables
+
+`template/cookiecutter.json` should include:
+
+- `project_name`: default `my_plugin`.
+- `app_code`: the plugin SaaS app code.
+- `plugin_desc`: default plugin description.
+- `init_apigw_maintainer`: default `admin`.
+- `framework_version`: default to the latest official framework tag that includes the detail/form alignment behavior.
+- `runtime_version`: default to the latest official runtime tag compatible with that framework tag.
+
+If no released tag contains the required detail/form behavior yet, the implementation plan must include the release/version-bump step or leave the defaults configurable without claiming release-tag end-to-end success.
+
+APIGW manager URL, timeout, release version, callback secret, and backend host should not be hardcoded in the template. They are runtime/PaaS environment concerns and already have documented conventions in `bk-plugin-runtime-go`.
+
+## Generated Plugin Behavior
+
+The generated plugin has one version: `1.0.0` in `versions/v100`.
+
+Types:
+
+- `Inputs`: `{ hello string }`.
+- `ContextInputs`: `{ executor string }`.
+- `Outputs`: `{ world string }`.
+
+Execution:
+
+1. If the context state is not `constants.StateEmpty`, return a clear unsupported-state error.
+2. Read `Inputs`.
+3. Read `ContextInputs`.
+4. Write `Outputs{World: inputs.Hello}`.
+5. Return nil, causing a synchronous success.
+
+The default plugin does not call `WaitPoll`, `PrepareCallback`, or `WaitCallback`.
+
+## Registration
+
+`main.go` should register the version with `hub.MustInstallV2`:
+
+```go
+hub.MustInstallV2(&v100.Plugin{}, hub.PluginSpec{
+    Inputs:        v100.Inputs{},
+    ContextInputs: v100.ContextInputs{},
+    Outputs:       v100.Outputs{},
+    Form:          v100.InputsForm,
+})
+```
+
+Then it should call `runner.Run()` from `github.com/TencentBlueKing/bk-plugin-runtime-go/runner`.
+
+Finish callback is not enabled by default. The README can show users how to opt in with `hub.Configure(hub.Options{EnablePluginCallback: true})`.
+
+## Deployment Flow
+
+`app_desc.yml` should default to PaaS v3 using the Python template's shape:
+
+- `specVersion: 3`.
+- `modules` list with module `default`.
+- `spec.hooks.preRelease.procCommand: bash bin/sync_apigateway.sh`.
+- `spec.processes` containing:
+  - web process: `{{cookiecutter.project_name}} server`.
+  - worker process: `{{cookiecutter.project_name}} worker`.
+- services: MySQL and Redis.
+- env values:
+  - `BK_APIGW_MAINTAINERS={{cookiecutter.init_apigw_maintainer}}`.
+
+`bin/sync_apigateway.sh` should:
+
+```bash
+{{cookiecutter.project_name}} syncapigw
+{{cookiecutter.project_name}} fetch-apigw-public-key
+```
+
+The script should use `set -euo pipefail` and print concise begin/done logs.
+
+The generated README should include a short `spec_version: 2` adaptation snippet for older Go plugin deployment environments:
+
+- `processes.web.command: {{cookiecutter.project_name}} server`
+- `processes.worker.command: {{cookiecutter.project_name}} worker`
+- services: MySQL and Redis, with RabbitMQ added only if the target platform requires it.
+
+## Protocol Alignment
+
+Python framework detail responses return:
+
+- generated input schema under `inputs`;
+- generated context schema under `context_inputs`;
+- generated output schema under `outputs`;
+- render form content under `forms.renderform`.
+
+Current Go framework stores `PluginDetail.FormsRenderFormJSON()` for `MustInstallV2`, but `protocol.BuildDetail` only returns `DetailOptions.RenderForm`. Current runtime calls `BuildDetail` without passing the stored form. This means `forms.renderform` can be null even when a plugin registered form metadata.
+
+The implementation should make `MustInstallV2` detail responses include the stored form as `forms.renderform`. Legacy `hub.MustInstall` should keep its existing behavior: the legacy form remains the input schema compatibility payload and should not unexpectedly appear as a separate renderform.
+
+Acceptable implementation shape:
+
+- Update `protocol.BuildDetail` to default `forms.renderform` from the plugin detail's stored form metadata.
+- Preserve the ability for runtime options to override renderform if needed.
+- Adjust runtime tests that currently assert `renderform == nil` for `MustInstallV2`.
+- Keep tests that assert legacy `MustInstall` does not expose a separate renderform.
+
+## Error Handling
+
+Template plugin errors should be explicit and ordinary Go errors:
+
+- unsupported state: include the numeric state value;
+- input/context read failures: return the original read error;
+- output write failure: return the original write error.
+
+The sync script should fail fast. Any `syncapigw` or `fetch-apigw-public-key` failure should fail the pre-release hook, matching the Python template's deployment posture.
+
+The generated README should call out that callback features require `BK_PLUGIN_CALLBACK_TOKEN_SECRET`, but the default synchronous plugin does not require callback configuration.
+
+## Testing
+
+Framework/runtime protocol tests:
+
+- `go test ./protocol -count=1`
+- `go test ./hub -count=1`
+- runtime-side tests that cover `/bk_plugin/detail/:version` after the protocol fix, if the runtime repository is part of the implementation pass.
+
+Template tests:
+
+- Render the cookiecutter template into a temporary project.
+- Run `go test ./... -count=1` in the rendered project.
+- Verify `go test` exercises the default plugin with an in-memory `kit.Context`.
+- Optionally run `go build ./...` in the rendered project.
+
+Static checks:
+
+- `git diff --check`
+- Ensure `rg "beego-runtime|app.json|post-compile|database/migrations" template` has no unexpected matches.
+- Ensure the template dependency pins point at official tags that include the protocol behavior required by this design.
+
+## Success Criteria
+
+- A newly rendered Go plugin project compiles and passes tests without user code changes.
+- The default plugin can be deployed with PaaS v3 configuration.
+- APIGW sync and public-key fetch are wired through the generated pre-release hook.
+- Detail API for the default plugin includes explicit schemas and `forms.renderform`.
+- Legacy `MustInstall` compatibility remains intact.
+- The template is smaller and cleaner than `origin/main_with_template`, while keeping the useful cookiecutter shape.

--- a/hub/registry.go
+++ b/hub/registry.go
@@ -79,6 +79,7 @@ type PluginDetail struct {
 	contextInputsSchemaJSON map[string]interface{}
 	outputsSchemaJSON       map[string]interface{}
 	formsRenderFormJSON     map[string]interface{}
+	formsRenderFormEnabled  bool
 }
 
 // Plugin returns the Plugin instance.
@@ -119,6 +120,12 @@ func (p *PluginDetail) OutputsSchemaJSON() map[string]interface{} {
 // FormsRenderFormJSON returns the unmarshaled render form metadata.
 func (p *PluginDetail) FormsRenderFormJSON() map[string]interface{} {
 	return p.formsRenderFormJSON
+}
+
+// FormsRenderFormEnabled returns whether the render form metadata should be
+// exposed as forms.renderform in the plugin detail protocol.
+func (p *PluginDetail) FormsRenderFormEnabled() bool {
+	return p.formsRenderFormEnabled
 }
 
 // PluginSpec describes a plugin version with explicit schemas and form metadata.
@@ -209,6 +216,7 @@ func mustInstallDetail(p kit.Plugin, spec PluginSpec, legacyInputsFormAsSchema b
 			panic(err)
 		}
 	}
+	formsRenderFormEnabled := !legacyInputsFormAsSchema && len(spec.Form) > 0
 	if legacyInputsFormAsSchema {
 		inputsSchema = spec.Form
 		inputsSchemaJSON = formsRenderFormJSON
@@ -223,6 +231,7 @@ func mustInstallDetail(p kit.Plugin, spec PluginSpec, legacyInputsFormAsSchema b
 		contextInputsSchemaJSON: contextInputsSchemaJSON,
 		outputsSchemaJSON:       outputsSchemaJSON,
 		formsRenderFormJSON:     formsRenderFormJSON,
+		formsRenderFormEnabled:  formsRenderFormEnabled,
 	}
 }
 

--- a/hub/registry_test.go
+++ b/hub/registry_test.go
@@ -80,6 +80,7 @@ func TestPluginDetailPlugin(t *testing.T) {
 		contextInputsSchemaJSON: contextInputsSchemaJSON,
 		outputsSchemaJSON:       outputsSchemaJSON,
 		formsRenderFormJSON:     formsRenderFormJSON,
+		formsRenderFormEnabled:  true,
 	}
 
 	assert.Equal(t, detail.Plugin(), &plugin)
@@ -90,6 +91,7 @@ func TestPluginDetailPlugin(t *testing.T) {
 	assert.Equal(t, detail.ContextInputsSchemaJSON(), contextInputsSchemaJSON)
 	assert.Equal(t, detail.OutputsSchemaJSON(), outputsSchemaJSON)
 	assert.Equal(t, detail.FormsRenderFormJSON(), formsRenderFormJSON)
+	assert.True(t, detail.FormsRenderFormEnabled())
 }
 
 func TestReflectJSONSchema(t *testing.T) {
@@ -252,6 +254,7 @@ func TestMustInstallLegacyKeepsInputsFormAsInputsSchema(t *testing.T) {
 		},
 	}, detail.InputsSchemaJSON())
 	assert.Equal(t, detail.FormsRenderFormJSON(), detail.InputsSchemaJSON())
+	assert.False(t, detail.FormsRenderFormEnabled())
 }
 
 func TestMustInstallV2StoresExplicitSchemasAndForm(t *testing.T) {
@@ -285,6 +288,7 @@ func TestMustInstallV2StoresExplicitSchemasAndForm(t *testing.T) {
 		"template_id": map[string]interface{}{"component": "input-number"},
 		"task_name":   map[string]interface{}{"component": "input"},
 	}, detail.FormsRenderFormJSON())
+	assert.True(t, detail.FormsRenderFormEnabled())
 }
 
 func TestGetPluginVersions(t *testing.T) {

--- a/info/version.go
+++ b/info/version.go
@@ -11,7 +11,7 @@
 package info
 
 const (
-	version = "v1.0.3"
+	version = "v1.0.4"
 )
 
 // Version returns the current version number of bk-plugin-framework-go.

--- a/protocol/detail.go
+++ b/protocol/detail.go
@@ -39,6 +39,12 @@ func BuildDetail(version string, opts DetailOptions) (DetailData, error) {
 	if err != nil {
 		return DetailData{}, err
 	}
+
+	renderForm := opts.RenderForm
+	if renderForm == nil && detail.FormsRenderFormEnabled() {
+		renderForm = detail.FormsRenderFormJSON()
+	}
+
 	return DetailData{
 		Version:              detail.Plugin().Version(),
 		Desc:                 detail.Plugin().Desc(),
@@ -47,7 +53,7 @@ func BuildDetail(version string, opts DetailOptions) (DetailData, error) {
 		ContextInputs:        detail.ContextInputsSchemaJSON(),
 		Outputs:              detail.OutputsSchemaJSON(),
 		Forms: DetailForms{
-			RenderForm: opts.RenderForm,
+			RenderForm: renderForm,
 		},
 	}, nil
 }

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -76,7 +76,7 @@ func TestBuildMetaUsesFrameworkProtocolContract(t *testing.T) {
 	require.Contains(t, string(raw), `"allow_scope":{}`)
 }
 
-func TestBuildDetailKeepsGoJSONSchemaOutOfRenderForm(t *testing.T) {
+func TestBuildDetailIncludesExplicitRenderForm(t *testing.T) {
 	version := nextProtocolTestVersion()
 	hub.MustInstallV2(protocolTestPlugin{version: version, desc: "detail plugin"}, hub.PluginSpec{
 		Inputs: struct {
@@ -95,11 +95,13 @@ func TestBuildDetailKeepsGoJSONSchemaOutOfRenderForm(t *testing.T) {
 	require.True(t, data.EnablePluginCallback)
 	require.Contains(t, data.Inputs["properties"], "mode")
 	require.Contains(t, data.Outputs["properties"], "ok")
-	require.Nil(t, data.Forms.RenderForm)
+	require.Equal(t, map[string]interface{}{
+		"mode": map[string]interface{}{"component": "input"},
+	}, data.Forms.RenderForm)
 
 	raw, err := json.Marshal(data)
 	require.NoError(t, err)
-	require.Contains(t, string(raw), `"renderform":null`)
+	require.Contains(t, string(raw), `"renderform":{"mode":{"component":"input"}}`)
 }
 
 func TestBuildDetailKeepsLegacyInputsFormAsInputs(t *testing.T) {

--- a/template/cookiecutter.json
+++ b/template/cookiecutter.json
@@ -1,0 +1,8 @@
+{
+  "project_name": "my_plugin",
+  "app_code": "the app code of plugin saas",
+  "plugin_desc": "the description of this plugin",
+  "init_apigw_maintainer": "admin",
+  "framework_version": "v1.0.4",
+  "runtime_version": "v0.2.5"
+}

--- a/template/{{cookiecutter.project_name}}/.gitignore
+++ b/template/{{cookiecutter.project_name}}/.gitignore
@@ -1,0 +1,18 @@
+# Build outputs
+bin/apigw.pub
+dist/
+build/
+*.test
+
+# Go
+vendor/
+coverage.out
+
+# Logs and local env
+v3logs/
+.env
+
+# Editors and OS files
+.idea/
+.vscode/
+.DS_Store

--- a/template/{{cookiecutter.project_name}}/README.md
+++ b/template/{{cookiecutter.project_name}}/README.md
@@ -1,0 +1,76 @@
+# {{cookiecutter.project_name}}
+
+{{cookiecutter.plugin_desc}}
+
+## Structure
+
+```text
+.
+├── app_desc.yml
+├── bin/sync_apigateway.sh
+├── main.go
+└── versions/v100
+    ├── form.json
+    ├── plugin.go
+    └── plugin_test.go
+```
+
+The default version is `1.0.0`. It reads `hello` and writes `world` with the same value.
+
+## Local Checks
+
+```bash
+go test ./... -count=1
+go build ./...
+```
+
+## Runtime Commands
+
+```bash
+{{cookiecutter.project_name}} server
+{{cookiecutter.project_name}} worker
+{{cookiecutter.project_name}} syncapigw
+{{cookiecutter.project_name}} fetch-apigw-public-key
+```
+
+## PaaS Deployment
+
+`app_desc.yml` uses PaaS v3 by default. The pre-release hook runs:
+
+```bash
+bash bin/sync_apigateway.sh
+```
+
+The script syncs the runtime-owned APIGW resources and fetches the gateway public key into `bin/apigw.pub`.
+
+Important environment variables are injected by PaaS or configured on the app:
+
+- `BKPAAS_APP_ID`
+- `BKPAAS_APP_SECRET`
+- `BKPAAS_DEFAULT_PREALLOCATED_URLS`
+- `BK_APIGW_MANAGER_URL_TMPL`
+- `BK_APIGW_MAINTAINERS`
+
+The default synchronous plugin does not require callback configuration. If you enable callback features later, configure `BK_PLUGIN_CALLBACK_TOKEN_SECRET`.
+
+## Legacy `spec_version: 2` Deployment
+
+If the target environment still uses the older Go app descriptor shape, adapt the process section to:
+
+```yaml
+spec_version: 2
+modules:
+  default:
+    language: go
+    is_default: true
+    processes:
+      web:
+        command: {{cookiecutter.project_name}} server
+      worker:
+        command: {{cookiecutter.project_name}} worker
+    services:
+      - name: mysql
+      - name: redis
+```
+
+Add RabbitMQ only if your platform requires it for this runtime deployment.

--- a/template/{{cookiecutter.project_name}}/README.md
+++ b/template/{{cookiecutter.project_name}}/README.md
@@ -29,6 +29,8 @@ go build ./...
 
 The default framework version is `{{cookiecutter.framework_version}}`. It must exist as an official Go module tag for normal dependency resolution. When validating an unreleased template branch locally, add a temporary `replace github.com/TencentBlueKing/bk-plugin-framework-go => <local-framework-checkout>` and remove it before release.
 
+The template includes a public `replace github.com/TencentBlueKing/gopkg v1.3.0 => github.com/TencentBlueKing/gopkg v1.0.9` for `bk-plugin-runtime-go {{cookiecutter.runtime_version}}`. This matches the runtime repository and keeps `bk-apigateway-sdks v1.1.4` on the compatible cache API until a newer runtime tag removes the need.
+
 ## Runtime Commands
 
 ```bash

--- a/template/{{cookiecutter.project_name}}/README.md
+++ b/template/{{cookiecutter.project_name}}/README.md
@@ -19,10 +19,15 @@ The default version is `1.0.0`. It reads `hello` and writes `world` with the sam
 
 ## Local Checks
 
+Run dependency resolution once before tests. This creates `go.sum` in the generated project.
+
 ```bash
+go mod tidy
 go test ./... -count=1
 go build ./...
 ```
+
+The default framework version is `{{cookiecutter.framework_version}}`. It must exist as an official Go module tag for normal dependency resolution. When validating an unreleased template branch locally, add a temporary `replace github.com/TencentBlueKing/bk-plugin-framework-go => <local-framework-checkout>` and remove it before release.
 
 ## Runtime Commands
 

--- a/template/{{cookiecutter.project_name}}/app_desc.yml
+++ b/template/{{cookiecutter.project_name}}/app_desc.yml
@@ -1,0 +1,28 @@
+specVersion: 3
+modules:
+  - name: default
+    isDefault: true
+    language: go
+    spec:
+      hooks:
+        preRelease:
+          procCommand: bash bin/sync_apigateway.sh
+      processes:
+        - name: web
+          procCommand: {{cookiecutter.project_name}} server
+          services:
+            - name: web
+              exposedType:
+                name: bk/http
+              targetPort: 5000
+              port: 80
+        - name: worker
+          procCommand: {{cookiecutter.project_name}} worker
+      services:
+        - name: mysql
+        - name: redis
+      configuration:
+        env:
+          - name: BK_APIGW_MAINTAINERS
+            value: {{cookiecutter.init_apigw_maintainer}}
+            description: plugin apigw maintainers

--- a/template/{{cookiecutter.project_name}}/app_desc.yml
+++ b/template/{{cookiecutter.project_name}}/app_desc.yml
@@ -24,5 +24,5 @@ modules:
       configuration:
         env:
           - name: BK_APIGW_MAINTAINERS
-            value: {{cookiecutter.init_apigw_maintainer}}
+            value: "{{cookiecutter.init_apigw_maintainer}}"
             description: plugin apigw maintainers

--- a/template/{{cookiecutter.project_name}}/bin/sync_apigateway.sh
+++ b/template/{{cookiecutter.project_name}}/bin/sync_apigateway.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[Sync] BEGIN ====================="
+
+{{cookiecutter.project_name}} syncapigw
+{{cookiecutter.project_name}} fetch-apigw-public-key
+
+echo "[Sync] DONE ====================="

--- a/template/{{cookiecutter.project_name}}/go.mod
+++ b/template/{{cookiecutter.project_name}}/go.mod
@@ -9,3 +9,8 @@ require (
 	github.com/TencentBlueKing/bk-plugin-runtime-go {{cookiecutter.runtime_version}}
 	github.com/sirupsen/logrus v1.9.2
 )
+
+// bk-plugin-runtime-go v0.2.5 uses bk-apigateway-sdks v1.1.4, which expects
+// the pre-v1.3 gopkg cache API. Keep this public replace until a runtime tag
+// no longer requires it.
+replace github.com/TencentBlueKing/gopkg v1.3.0 => github.com/TencentBlueKing/gopkg v1.0.9

--- a/template/{{cookiecutter.project_name}}/go.mod
+++ b/template/{{cookiecutter.project_name}}/go.mod
@@ -1,0 +1,11 @@
+// +heroku install {{cookiecutter.project_name}}
+// +heroku goVersion go1.23
+module {{cookiecutter.project_name}}
+
+go 1.23.0
+
+require (
+	github.com/TencentBlueKing/bk-plugin-framework-go {{cookiecutter.framework_version}}
+	github.com/TencentBlueKing/bk-plugin-runtime-go {{cookiecutter.runtime_version}}
+	github.com/sirupsen/logrus v1.9.2
+)

--- a/template/{{cookiecutter.project_name}}/main.go
+++ b/template/{{cookiecutter.project_name}}/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/TencentBlueKing/bk-plugin-framework-go/hub"
+	"github.com/TencentBlueKing/bk-plugin-runtime-go/runner"
+	v100 "{{cookiecutter.project_name}}/versions/v100"
+)
+
+func main() {
+	hub.MustInstallV2(&v100.Plugin{}, hub.PluginSpec{
+		Inputs:        v100.Inputs{},
+		ContextInputs: v100.ContextInputs{},
+		Outputs:       v100.Outputs{},
+		Form:          v100.InputsForm,
+	})
+	runner.Run()
+}

--- a/template/{{cookiecutter.project_name}}/versions/v100/form.json
+++ b/template/{{cookiecutter.project_name}}/versions/v100/form.json
@@ -1,0 +1,14 @@
+{
+  "hello": {
+    "type": "string",
+    "title": "Hello",
+    "default": "",
+    "ui:component": {
+      "name": "bk-input",
+      "props": {}
+    },
+    "ui:rules": [
+      "required"
+    ]
+  }
+}

--- a/template/{{cookiecutter.project_name}}/versions/v100/plugin.go
+++ b/template/{{cookiecutter.project_name}}/versions/v100/plugin.go
@@ -1,0 +1,60 @@
+package v100
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/TencentBlueKing/bk-plugin-framework-go/constants"
+	"github.com/TencentBlueKing/bk-plugin-framework-go/kit"
+)
+
+//go:embed form.json
+var InputsForm []byte
+
+// Inputs defines the visible plugin inputs.
+type Inputs struct {
+	Hello string `json:"hello" jsonschema:"title=Hello"`
+}
+
+// ContextInputs defines Standard Ops context inputs used by the plugin.
+type ContextInputs struct {
+	Executor string `json:"executor" jsonschema:"title=Executor"`
+}
+
+// Outputs defines the values returned to the caller.
+type Outputs struct {
+	World string `json:"world" jsonschema:"title=World"`
+}
+
+// Plugin implements version 1.0.0.
+type Plugin struct{}
+
+// Version returns the plugin version.
+func (p *Plugin) Version() string {
+	return "1.0.0"
+}
+
+// Desc returns the plugin description.
+func (p *Plugin) Desc() string {
+	return "{{cookiecutter.plugin_desc}}"
+}
+
+// Execute runs the synchronous hello/world plugin.
+func (p *Plugin) Execute(c *kit.Context) error {
+	if c.State() != constants.StateEmpty {
+		return fmt.Errorf("hello world plugin does not support state %v", c.State())
+	}
+
+	var inputs Inputs
+	if err := c.ReadInputs(&inputs); err != nil {
+		return err
+	}
+
+	var contextInputs ContextInputs
+	if err := c.ReadContextInputs(&contextInputs); err != nil {
+		return err
+	}
+	_ = contextInputs
+
+	return c.WriteOutputs(&Outputs{World: inputs.Hello})
+}

--- a/template/{{cookiecutter.project_name}}/versions/v100/plugin_test.go
+++ b/template/{{cookiecutter.project_name}}/versions/v100/plugin_test.go
@@ -1,0 +1,97 @@
+package v100
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/TencentBlueKing/bk-plugin-framework-go/constants"
+	"github.com/TencentBlueKing/bk-plugin-framework-go/kit"
+	"github.com/sirupsen/logrus"
+)
+
+type testReader struct {
+	inputs        map[string]interface{}
+	contextInputs map[string]interface{}
+}
+
+func (r testReader) ReadInputs(v interface{}) error {
+	return marshalTo(r.inputs, v)
+}
+
+func (r testReader) ReadContextInputs(v interface{}) error {
+	return marshalTo(r.contextInputs, v)
+}
+
+type testStore struct {
+	data map[string][]byte
+}
+
+func newTestStore() *testStore {
+	return &testStore{data: map[string][]byte{}}
+}
+
+func (s *testStore) Write(traceID string, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	s.data[traceID] = data
+	return nil
+}
+
+func (s *testStore) Read(traceID string, v interface{}) error {
+	return json.Unmarshal(s.data[traceID], v)
+}
+
+func marshalTo(src interface{}, dst interface{}) error {
+	data, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, dst)
+}
+
+func TestHelloWorldPluginWritesOutput(t *testing.T) {
+	contextStore := newTestStore()
+	outputsStore := newTestStore()
+	reader := testReader{
+		inputs: map[string]interface{}{
+			"hello": "world",
+		},
+		contextInputs: map[string]interface{}{
+			"executor": "admin",
+		},
+	}
+
+	plugin := &Plugin{}
+	c := kit.NewContext("trace-hello", constants.StateEmpty, 1, reader, contextStore, outputsStore, logrus.NewEntry(logrus.StandardLogger()))
+	if err := plugin.Execute(c); err != nil {
+		t.Fatalf("execute plugin: %v", err)
+	}
+	if c.WaitingPoll() || c.WaitingCallback() {
+		t.Fatalf("default plugin should finish synchronously")
+	}
+
+	var outputs Outputs
+	if err := outputsStore.Read("trace-hello", &outputs); err != nil {
+		t.Fatalf("read outputs: %v", err)
+	}
+	if outputs.World != "world" {
+		t.Fatalf("World = %q, want %q", outputs.World, "world")
+	}
+}
+
+func TestHelloWorldPluginRejectsUnsupportedState(t *testing.T) {
+	contextStore := newTestStore()
+	outputsStore := newTestStore()
+	reader := testReader{
+		inputs:        map[string]interface{}{"hello": "world"},
+		contextInputs: map[string]interface{}{"executor": "admin"},
+	}
+
+	plugin := &Plugin{}
+	c := kit.NewContext("trace-poll", constants.StatePoll, 2, reader, contextStore, outputsStore, logrus.NewEntry(logrus.StandardLogger()))
+	if err := plugin.Execute(c); err == nil {
+		t.Fatalf("expected unsupported state error")
+	}
+}


### PR DESCRIPTION
## Summary

- Expose explicit `MustInstallV2` form metadata as `forms.renderform` in the plugin detail protocol while keeping legacy `MustInstall` behavior unchanged.
- Add a cookiecutter Go plugin template with PaaS v3 `app_desc.yml`, runtime `v0.2.5`, framework `v1.0.4`, APIGW sync/public-key pre-release hook, and a default `hello -> world` plugin version.
- Document template validation, v2 deployment adaptation, and the temporary public `gopkg v1.3.0 => v1.0.9` compatibility replace required by the current runtime dependency graph.

## Why

This gives new Go standard plugin projects an initialization template aligned with the Python framework template and the newer Go runtime path, so generated projects can be tested and deployed without editing source code after the target framework tag is published.

## Notes

- `github.com/TencentBlueKing/bk-plugin-framework-go v1.0.4` must be published before generated projects can resolve dependencies without a local framework replace.
- The template intentionally does not commit `go.sum` because `v1.0.4` is not available yet.
- The `gopkg` replace is public and mirrors the compatibility requirement observed with `bk-plugin-runtime-go v0.2.5` and `bk-apigateway-sdks v1.1.4`.

## Test Plan

- [x] `go test ./... -count=1`
- [x] `git diff --check`
- [x] Render template with `cookiecutter`
- [x] Run `go mod tidy` in rendered project with temporary local framework replace
- [x] `go test ./... -count=1` in rendered project
- [x] `go build ./...` in rendered project
