### PR TITLE
chore: bump template runtime to v0.2.8

### DIFF
--- a/template/cookiecutter.json
+++ b/template/cookiecutter.json
@@ -4,5 +4,5 @@
   "plugin_desc": "the description of this plugin",
   "init_apigw_maintainer": "admin",
   "framework_version": "v1.0.4",
-  "runtime_version": "v0.2.5"
+  "runtime_version": "v0.2.8"
 }

--- a/template/{{cookiecutter.project_name}}/go.mod
+++ b/template/{{cookiecutter.project_name}}/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/sirupsen/logrus v1.9.2
 )
 
-// bk-plugin-runtime-go v0.2.5 uses bk-apigateway-sdks v1.1.4, which expects
+// bk-plugin-runtime-go v0.2.8 uses bk-apigateway-sdks v1.1.4, which expects
 // the pre-v1.3 gopkg cache API. Keep this public replace until a runtime tag
 // no longer requires it.
 replace github.com/TencentBlueKing/gopkg v1.3.0 => github.com/TencentBlueKing/gopkg v1.0.9


### PR DESCRIPTION
## Summary

- update the cookiecutter default runtime from `v0.2.5` to `v0.2.8`
- align the generated `go.mod` compatibility comment with the new runtime version
- keep the existing `gopkg v1.3.0 => v1.0.9` replace because runtime `v0.2.8` still depends on `bk-apigateway-sdks v1.1.4`

## Why

`v0.2.8` is the latest published runtime tag. It includes plugin API dispatch compatibility fixes, invoke failure response compatibility, and bounded MySQL connection lifetime settings.

Newly generated plugins should use the latest compatible runtime by default.

## Validation

- `python -m json.tool template/cookiecutter.json`
- `go test ./... -count=1`
- rendered the cookiecutter template into a temporary project
- rendered project: `go mod tidy`
- rendered project: `go list -m github.com/TencentBlueKing/bk-plugin-runtime-go` returned `v0.2.8`
- rendered project: `go test ./... -count=1`
- rendered project: `go build ./...`